### PR TITLE
[Bugfix] Ensure seamless execution of vagrant script

### DIFF
--- a/vagrant/config.sh
+++ b/vagrant/config.sh
@@ -42,8 +42,8 @@ sed -i 's/127.0.0.1\/32/0.0.0.0\/0/g' /media/data/pg_data/data/pg_hba.conf
  
 echo "listen_addresses = '*'" >> /media/data/pg_data/data/postgresql.conf
 sed -i 's/shared_buffers = 128MB/shared_buffers = 4GB/g' /media/data/pg_data/data/postgresql.conf
-echo "shared_preload_libraries = 'pg_session_stats'" >> /media/data/pg_data/data/postgresql.conf
-echo "pg_session_stats.path = '/media/data/pg_data/pgss.sqlite3'" >> /media/data/pg_data/data/postgresql.conf
+#echo "shared_preload_libraries = 'pg_session_stats'" >> /media/data/pg_data/data/postgresql.conf
+#echo "pg_session_stats.path = '/media/data/pg_data/pgss.sqlite3'" >> /media/data/pg_data/data/postgresql.conf
 
 #systemctl stop postgresql
 #git clone https://github.com/RyanMarcus/pg_session_stats.git

--- a/vagrant/config.sh
+++ b/vagrant/config.sh
@@ -45,8 +45,7 @@ sed -i 's/shared_buffers = 128MB/shared_buffers = 4GB/g' /media/data/pg_data/dat
 echo "shared_preload_libraries = 'pg_session_stats'" >> /media/data/pg_data/data/postgresql.conf
 echo "pg_session_stats.path = '/media/data/pg_data/pgss.sqlite3'" >> /media/data/pg_data/data/postgresql.conf
 
-systemctl stop postgresql
-
+#systemctl stop postgresql
 #git clone https://github.com/RyanMarcus/pg_session_stats.git
 #cd pg_session_stats
 #make USE_PGXS=1 install

--- a/vagrant/config.sh
+++ b/vagrant/config.sh
@@ -56,7 +56,8 @@ sed -i 's/shared_buffers = 128MB/shared_buffers = 4GB/g' /media/data/pg_data/dat
 #cd pg_dropcache
 #make USE_PGXS=1 install
 #cd
-#systemctl restart postgresql
+
+systemctl restart postgresql
 
 
 # get the archive locally, if we have it


### PR DESCRIPTION
Current version of `config.sh` runs `systemctl stop postgresql` right before importing the data, causing failure. This PR comments out the faulty command. It also comments out the inconsistent configuration option in `postgresql.conf` if pg_session_stats is not installed.